### PR TITLE
Typed remote config reads; native SDKs 7.0.14 (iOS) and 7.0.13 (Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ ScateSDK.EventWithValue("button_clicked", "subscribe_btn");
 
 ScateSDK.GetRemoteConfig('key', 'defaultValue');
 
+// Typed reads fall back to the default when the value is not of that type.
+final enabled = await ScateSDK.GetRemoteConfigBool('new_camera', false);
+final limit = await ScateSDK.GetRemoteConfigInt('scan_limit', 10);
+final ratio = await ScateSDK.GetRemoteConfigDouble('crop_ratio', 1.5);
+
 ```
 
 ### Add Listener

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'com.scate:scatesdk:7.0.12'
+        implementation 'com.scate:scatesdk:7.0.13'
         implementation 'com.adjust.sdk:adjust-android:5.6.0'
         implementation 'com.android.installreferrer:installreferrer:2.2'
     }

--- a/android/src/main/kotlin/com/scate/scatesdk_flutter/ScatesdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/scate/scatesdk_flutter/ScatesdkFlutterPlugin.kt
@@ -111,6 +111,21 @@ class ScatesdkFlutterPlugin: FlutterPlugin, MethodCallHandler, StreamHandler {
                 val value = ScateCoreSDK.getRemoteConfig(key, defaultValue)
                 result.success(value)
             }
+            "GetRemoteConfigBool" -> {
+                val key: String? = call.argument("key")
+                val defaultValue: Boolean = call.argument("defaultValue") ?: false
+                result.success(ScateCoreSDK.getRemoteConfigBoolean(key, defaultValue))
+            }
+            "GetRemoteConfigInt" -> {
+                val key: String? = call.argument("key")
+                val defaultValue: Int = call.argument("defaultValue") ?: 0
+                result.success(ScateCoreSDK.getRemoteConfigInt(key, defaultValue))
+            }
+            "GetRemoteConfigDouble" -> {
+                val key: String? = call.argument("key")
+                val defaultValue: Double = call.argument("defaultValue") ?: 0.0
+                result.success(ScateCoreSDK.getRemoteConfigDouble(key, defaultValue))
+            }
             "AddListener" -> {
                 result.success(null)
             }

--- a/ios/Classes/ScatesdkFlutterPlugin.swift
+++ b/ios/Classes/ScatesdkFlutterPlugin.swift
@@ -103,6 +103,30 @@ public class ScatesdkFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
             }
             let value = ScateCoreSDK.GetRemoteConfig(key: key, defaultValue: defaultValue)
             result(value)
+        case "GetRemoteConfigBool":
+            guard let args = call.arguments as? [String: Any],
+                  let key = args["key"] as? String,
+                  let defaultValue = args["defaultValue"] as? Bool else {
+                result(FlutterError(code: "INVALID_ARGUMENT", message: "Missing key or defaultValue", details: nil))
+                return
+            }
+            result(ScateCoreSDK.GetRemoteConfigBool(key: key, defaultValue: defaultValue))
+        case "GetRemoteConfigInt":
+            guard let args = call.arguments as? [String: Any],
+                  let key = args["key"] as? String,
+                  let defaultValue = args["defaultValue"] as? Int else {
+                result(FlutterError(code: "INVALID_ARGUMENT", message: "Missing key or defaultValue", details: nil))
+                return
+            }
+            result(ScateCoreSDK.GetRemoteConfigInt(key: key, defaultValue: defaultValue))
+        case "GetRemoteConfigDouble":
+            guard let args = call.arguments as? [String: Any],
+                  let key = args["key"] as? String,
+                  let defaultValue = args["defaultValue"] as? Double else {
+                result(FlutterError(code: "INVALID_ARGUMENT", message: "Missing key or defaultValue", details: nil))
+                return
+            }
+            result(ScateCoreSDK.GetRemoteConfigDouble(key: key, defaultValue: defaultValue))
         case "AddListener":
             guard let args = call.arguments as? [String: Any],
                   let name = args["name"] as? String else {

--- a/ios/scatesdk_flutter.podspec
+++ b/ios/scatesdk_flutter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency "ScateSDK", "7.0.12"
+  s.dependency "ScateSDK", "7.0.14"
   s.dependency "Adjust/AdjustGoogleOdm", "~> 5.6.1"
   s.platform = :ios, '12.0'
 

--- a/lib/scatesdk_flutter.dart
+++ b/lib/scatesdk_flutter.dart
@@ -111,6 +111,23 @@ class ScateSDK {
         .GetRemoteConfig(key, defaultValue);
   }
 
+  /// Typed reads fall back to the default when the value is not of that type.
+  static Future<bool> GetRemoteConfigBool(String key, bool defaultValue) async {
+    return await ScatesdkFlutterPlatform.instance
+        .GetRemoteConfigBool(key, defaultValue);
+  }
+
+  static Future<int> GetRemoteConfigInt(String key, int defaultValue) async {
+    return await ScatesdkFlutterPlatform.instance
+        .GetRemoteConfigInt(key, defaultValue);
+  }
+
+  static Future<double> GetRemoteConfigDouble(
+      String key, double defaultValue) async {
+    return await ScatesdkFlutterPlatform.instance
+        .GetRemoteConfigDouble(key, defaultValue);
+  }
+
   static void AddListener(ScateEvents eventType, Function listener) {
     var name = eventType.name;
 

--- a/lib/scatesdk_flutter_method_channel.dart
+++ b/lib/scatesdk_flutter_method_channel.dart
@@ -172,6 +172,42 @@ class MethodChannelScatesdkFlutter extends ScatesdkFlutterPlatform {
     return null;
   }
 
+  @override
+  Future<bool> GetRemoteConfigBool(String key, bool defaultValue) async {
+    try {
+      final bool? value = await methodChannel.invokeMethod<bool>(
+          'GetRemoteConfigBool', {'key': key, 'defaultValue': defaultValue});
+      return value ?? defaultValue;
+    } on PlatformException catch (e) {
+      print("Failed to call GetRemoteConfigBool: '${e.message}'.");
+      return defaultValue;
+    }
+  }
+
+  @override
+  Future<int> GetRemoteConfigInt(String key, int defaultValue) async {
+    try {
+      final int? value = await methodChannel.invokeMethod<int>(
+          'GetRemoteConfigInt', {'key': key, 'defaultValue': defaultValue});
+      return value ?? defaultValue;
+    } on PlatformException catch (e) {
+      print("Failed to call GetRemoteConfigInt: '${e.message}'.");
+      return defaultValue;
+    }
+  }
+
+  @override
+  Future<double> GetRemoteConfigDouble(String key, double defaultValue) async {
+    try {
+      final double? value = await methodChannel.invokeMethod<double>(
+          'GetRemoteConfigDouble', {'key': key, 'defaultValue': defaultValue});
+      return value ?? defaultValue;
+    } on PlatformException catch (e) {
+      print("Failed to call GetRemoteConfigDouble: '${e.message}'.");
+      return defaultValue;
+    }
+  }
+
   Future<void> AddListener(String name) async {
     try {
       await methodChannel.invokeMethod('AddListener', {'name': name});

--- a/lib/scatesdk_flutter_platform_interface.dart
+++ b/lib/scatesdk_flutter_platform_interface.dart
@@ -82,6 +82,18 @@ abstract class ScatesdkFlutterPlatform extends PlatformInterface {
     return _instance.GetRemoteConfig(key, defaultValue);
   }
 
+  Future<bool> GetRemoteConfigBool(String key, bool defaultValue) async {
+    return _instance.GetRemoteConfigBool(key, defaultValue);
+  }
+
+  Future<int> GetRemoteConfigInt(String key, int defaultValue) async {
+    return _instance.GetRemoteConfigInt(key, defaultValue);
+  }
+
+  Future<double> GetRemoteConfigDouble(String key, double defaultValue) async {
+    return _instance.GetRemoteConfigDouble(key, defaultValue);
+  }
+
   Future<void> AddListener(String name) async {
     return _instance.AddListener(name);
   }


### PR DESCRIPTION
## Summary
- `GetRemoteConfigBool`, `GetRemoteConfigInt`, `GetRemoteConfigDouble` on the Dart API, the platform interface, the method channel and both native plugins, calling the typed getters the native SDKs gain in scate-io/ScateCoreSDK-ios#13 and scate-io/ScateCoreSDK-android#6. They fall back to the default when the value is not of that type or the call fails.
- Native pins: `ScateSDK` 7.0.14 and `com.scate:scatesdk` 7.0.13. Those versions exist once the native PRs are tagged; merge this after them.
- No other API change: A/B tests need nothing from the app, the native SDKs report them on their own.

## Verification
- Not run locally: this machine has no Flutter toolchain. The Dart changes mirror the existing `GetRemoteConfig` path line for line; please run `flutter analyze` / `flutter test` in CI or locally before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)