### PR TITLE
Flutter: EventWithValueAndParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- `EventWithValueAndParameters`: an event carrying both a custom value and parameters,
+  which the native SDKs and the React Native wrapper already had.
+
 ## 7.0.15
 
 - `GetRemoteConfigBool`, `GetRemoteConfigInt`, `GetRemoteConfigDouble`: typed remote config reads

--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ ScateSDK.EventWithValue("button_clicked", "subscribe_btn");
 
 ```
 
+### Send Events with Additional Data and Parameters
+
+```dart
+
+ScateSDK.EventWithValueAndParameters("button_clicked", "subscribe_btn", parameters: {
+  "screen": "paywall",
+  "position": 1,
+  "isPrimary": true,
+});
+
+```
+
 ### Get Remote Config for Key
 
 ```dart

--- a/android/src/main/kotlin/com/scate/scatesdk_flutter/ScatesdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/scate/scatesdk_flutter/ScatesdkFlutterPlugin.kt
@@ -105,6 +105,17 @@ class ScatesdkFlutterPlugin: FlutterPlugin, MethodCallHandler, StreamHandler {
                 ScateCoreSDK.event(name, value)
                 result.success(null)
             }
+            "EventWithValueAndParameters" -> {
+                val name: String? = call.argument("name")
+                val value: String? = call.argument("value")
+                val parameters: Map<String, Any?>? = call.argument("parameters")
+                if (parameters != null) {
+                    ScateCoreSDK.event(name, value, parameters)
+                } else {
+                    ScateCoreSDK.event(name, value)
+                }
+                result.success(null)
+            }
             "GetRemoteConfig" -> {
                 val key: String? = call.argument("key")
                 val defaultValue: String? = call.argument("defaultValue")

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,6 +70,16 @@ class _MyAppState extends State<MyApp> {
       },
     );
     await ScateSDK.EventWithValue("test_event", "test_value");
+    await ScateSDK.EventWithValueAndParameters(
+      "test_event_with_value_and_parameters",
+      "test_value",
+      parameters: {
+        "button_id": "flutter_example_purchase",
+        "attempt": 2,
+        "is_trial": false,
+        "price": 19.99,
+      },
+    );
     ScateSDK.OnboardingStart();
     ScateSDK.OnboardingStep("location_screen");
     ScateSDK.OnboardingStep("notification_screen");

--- a/ios/Classes/ScatesdkFlutterPlugin.swift
+++ b/ios/Classes/ScatesdkFlutterPlugin.swift
@@ -94,6 +94,19 @@ public class ScatesdkFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandle
             }
             ScateCoreSDK.Event(name: name, customValue: value)
             result(nil)
+        case "EventWithValueAndParameters":
+            guard let args = call.arguments as? [String: Any],
+                  let name = args["name"] as? String,
+                  let value = args["value"] as? String else {
+                result(FlutterError(code: "INVALID_ARGUMENT", message: "Missing name or value", details: nil))
+                return
+            }
+            if let parameters = args["parameters"] as? [String: Any] {
+                ScateCoreSDK.Event(name: name, customValue: value, parameters: parameters as NSDictionary)
+            } else {
+                ScateCoreSDK.Event(name: name, customValue: value)
+            }
+            result(nil)
         case "GetRemoteConfig":
             guard let args = call.arguments as? [String: Any],
                   let key = args["key"] as? String,

--- a/lib/scatesdk_flutter.dart
+++ b/lib/scatesdk_flutter.dart
@@ -105,6 +105,19 @@ class ScateSDK {
     await ScatesdkFlutterPlatform.instance.EventWithValue(name, value);
   }
 
+  /// An event carrying both a custom value and parameters.
+  static Future<void> EventWithValueAndParameters(
+    String name,
+    String value, {
+    Map<String, dynamic>? parameters,
+  }) async {
+    await ScatesdkFlutterPlatform.instance.EventWithValueAndParameters(
+      name,
+      value,
+      parameters: parameters,
+    );
+  }
+
   static Future<String?> GetRemoteConfig(
       String key, String defaultValue) async {
     return await ScatesdkFlutterPlatform.instance

--- a/lib/scatesdk_flutter_method_channel.dart
+++ b/lib/scatesdk_flutter_method_channel.dart
@@ -160,6 +160,23 @@ class MethodChannelScatesdkFlutter extends ScatesdkFlutterPlatform {
   }
 
   @override
+  Future<void> EventWithValueAndParameters(
+    String name,
+    String value, {
+    Map<String, dynamic>? parameters,
+  }) async {
+    try {
+      await methodChannel.invokeMethod('EventWithValueAndParameters', {
+        'name': name,
+        'value': value,
+        if (parameters != null) 'parameters': parameters,
+      });
+    } on PlatformException catch (e) {
+      print("Failed to call EventWithValueAndParameters: '${e.message}'.");
+    }
+  }
+
+  @override
   Future<String?> GetRemoteConfig(String key, String defaultValue) async {
     try {
       String config = await methodChannel.invokeMethod(

--- a/lib/scatesdk_flutter_platform_interface.dart
+++ b/lib/scatesdk_flutter_platform_interface.dart
@@ -78,6 +78,18 @@ abstract class ScatesdkFlutterPlatform extends PlatformInterface {
     return _instance.EventWithValue(name, value);
   }
 
+  Future<void> EventWithValueAndParameters(
+    String name,
+    String value, {
+    Map<String, dynamic>? parameters,
+  }) async {
+    return _instance.EventWithValueAndParameters(
+      name,
+      value,
+      parameters: parameters,
+    );
+  }
+
   Future<String?> GetRemoteConfig(String key, String defaultValue) async {
     return _instance.GetRemoteConfig(key, defaultValue);
   }


### PR DESCRIPTION
## Why

The native SDKs and the React Native wrapper take an event with both a custom value and parameters:

```
Android  ScateCoreSDK.event(name, customValue, parameters)
iOS      ScateCoreSDK.Event(name:customValue:parameters:)
RN       ScateSDK.EventWithValueAndParameters(name, customValue, parameters)
```

The Flutter wrapper never got it. It had `Event(name, {parameters})` and `EventWithValue(name, value)`, with no way to send both. This was missed when the three-argument form went into the natives and the RN bridge for 7.0.15.

## What

`ScateSDK.EventWithValueAndParameters(name, value, {parameters})` through every layer:

- `lib/scatesdk_flutter.dart`, the platform interface and the method channel;
- the Android plugin calls `ScateCoreSDK.event(name, value, parameters)`, falling back to the two-argument form when parameters are absent;
- the iOS plugin calls `ScateCoreSDK.Event(name:customValue:parameters:)`, same fallback;
- the example sends one, and the README and changelog cover it.

Naming follows the wrapper's existing style (`EventWithValue`) and the React Native method.

## Checks

Built and ran the example on both platforms, watching the SDK log.

- Pixel 7 emulator: `Process Event called -> {"customValue":"test_value","name":"test_event_with_value_and_parameters","parameters":"{\"price\":19.99,\"button_id\":\"flutter_example_purchase\",\"attempt\":2,\"is_trial\":false}"}`, then `HTTP Response Code: 200`.
- iPhone 17 Pro simulator: the same event on the wire with `customValue` and all four parameters.
- `flutter analyze`: no errors (the pre-existing warning and infos are unchanged).

Publishing needs a release; this rides along with the next common tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)