### PR TITLE
Name 7.0.17 in the changelog before the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.17
+
+- Updated native ScateSDK dependencies to 7.0.17 on both platforms: the
+  `scate_remote_configs_loaded` event reports `segment_override` and `ab_override`, and
+  the always-empty `country_override` is gone.
+
 ## 7.0.16
 
 - `EventWithValueAndParameters`: an event carrying both a custom value and parameters,


### PR DESCRIPTION
## Why

pub.dev refuses to publish a version its changelog does not mention; that is what stopped the 7.0.16 publish until the section was added and the tag moved. The release script's preflight now checks it, so the section has to be on `main` before the tag is pushed.

## What

The `## 7.0.17` section, describing what the native SDKs bring:

- `scate_remote_configs_loaded` reports `segment_override` and `ab_override`;
- the always-empty `country_override` is gone.

(scate-io/ScateCoreSDK-ios#14 and scate-io/ScateCoreSDK-android#8.)

The version fields themselves are not touched: the release workflow stamps `pubspec.yaml`, the README and the native pins from the tag.

## Checks

`flutter analyze`: no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)