### PR TITLE
Name 7.0.18 in the changelog before the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.18
+
+- Updated native ScateSDK dependencies to 7.0.18 on both platforms: `abName` and
+  `abVariant` are sent on every event, as empty strings when the user is in no test,
+  instead of being left out.
+
 ## 7.0.17
 
 - Updated native ScateSDK dependencies to 7.0.17 on both platforms: the


### PR DESCRIPTION
The `## 7.0.18` section, so the release preflight and pub.dev accept the version: the native SDKs send `abName` / `abVariant` on every event, as empty strings when the user is in no test (scate-io/ScateCoreSDK-ios and scate-io/ScateCoreSDK-android, "ab-fields-always-sent"). Version fields are stamped by the release workflow from the tag, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)